### PR TITLE
Declare MIT OR Apache-2.0 dual-license grant

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,3 +67,12 @@ just build-iso-laptop   # Laptop ISO
 just lint    # shellcheck
 just format  # shfmt
 ```
+
+## License
+
+Licensed under either of
+
+- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
+- MIT License ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+
+at your option.


### PR DESCRIPTION
## Summary

- Adds a License section to README.md declaring the MIT OR Apache-2.0 dual-license grant, pointing to the existing LICENSE-APACHE and LICENSE-MIT files.

## Test plan

- [ ] Verify LICENSE-APACHE and LICENSE-MIT files exist and are correct
- [ ] Verify README.md license section renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)