### PR TITLE
Add WezTerm nightly to desktop and laptop images

### DIFF
--- a/.serena/memories/project_overview.md
+++ b/.serena/memories/project_overview.md
@@ -24,9 +24,22 @@ just lint               # shellcheck all .sh files
 just format             # shfmt all .sh files
 ```
 
-## Active Branch / PR
-- Branch: `feature/laptop-lunar-lake`
-- PR #2: "Add Celastrina Laptop variant for Yoga 9 2-in-1" — OPEN
+## Key Issues
+- #5: Laptop post-install fixes (LUKS naming, iwlwifi panic, Tang, EFI label, installer improvements)
+- #8: Rebrand image from Bazzite to Celastrina (os-release, image-info.json, MOTD)
+
+## Branding
+`configure-branding.sh` handles all downstream branding:
+- KDE About System (`/etc/xdg/kcm-about-distrorc`)
+- `/usr/share/ublue-os/image-info.json` (ublue-motd, fastfetch)
+- `/usr/share/ublue-os/motd/celastrina.md` (replaces bazzite.md, patches `/usr/libexec/ublue-motd`)
+- `/usr/lib/os-release` (sed patches in-place, preserves upstream fields)
+- Desktop defaults to `CELASTRINA_IMAGE_NAME=celastrina`; laptop passes `celastrina-laptop`
+
+## Laptop Hardware Notes
+- iwlwifi_mld (Intel BE201 WiFi 7) causes kernel panic on Yoga 9 — blacklisted in image
+- LUKS boot fix: use `rd.luks.name=<UUID>=luks-root` instead of `rd.luks.uuid` (karg, not image change)
+- Kernel cmdline managed via `rpm-ostree kargs` on installed system
 
 ## Tech Stack
 - Bash scripts (Justfile recipes, installer)

--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -117,3 +117,19 @@ initial_prompt: ""
 # This overrides the corresponding setting in the global configuration; see the documentation there.
 # If null or missing, use the setting from the global configuration.
 symbol_info_budget:
+
+# The language backend to use for this project.
+# If not set, the global setting from serena_config.yml is used.
+# Valid values: LSP, JetBrains
+# Note: the backend is fixed at startup. If a project with a different backend
+# is activated post-init, an error will be returned.
+language_backend:
+
+# list of regex patterns which, when matched, mark a memory entry as read‑only.
+# Extends the list from the global configuration, merging the two lists.
+read_only_memory_patterns: []
+
+# line ending convention to use when writing source files.
+# Possible values: unset (use global setting), "lf", "crlf", or "native" (platform default)
+# This does not affect Serena's own files (e.g. memories and configuration files), which always use native line endings.
+line_ending:

--- a/build_files/build-laptop.sh
+++ b/build_files/build-laptop.sh
@@ -12,6 +12,7 @@ function install-system() {
 	/ctx/install-openh264-and-firefox.sh
 	/ctx/install-1password.sh
 	/ctx/install-chrome.sh
+	/ctx/install-wezterm.sh
 	/ctx/install-observability.sh
 	/ctx/configure-xdg-portal.sh
 	/ctx/configure-signing-policy.sh

--- a/build_files/build.sh
+++ b/build_files/build.sh
@@ -12,6 +12,7 @@ function install-system() {
     /ctx/install-openh264-and-firefox.sh
     /ctx/install-1password.sh
     /ctx/install-chrome.sh
+    /ctx/install-wezterm.sh
     /ctx/install-observability.sh
     /ctx/configure-xdg-portal.sh
     /ctx/configure-signing-policy.sh

--- a/build_files/install-wezterm.sh
+++ b/build_files/install-wezterm.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -ouex pipefail
+
+echo "Installing WezTerm (nightly)"
+
+# Add COPR repo for wezterm-nightly
+curl -fsSL "https://copr.fedorainfracloud.org/coprs/wezfurlong/wezterm-nightly/repo/fedora-$(rpm -E %fedora)/wezfurlong-wezterm-nightly-fedora-$(rpm -E %fedora).repo" \
+    -o /etc/yum.repos.d/wezfurlong-wezterm-nightly.repo
+
+# Install
+rpm-ostree install wezterm
+
+# Remove the repo — updates ship with new images
+rm /etc/yum.repos.d/wezfurlong-wezterm-nightly.repo


### PR DESCRIPTION
## Summary

- Adds WezTerm terminal emulator to both desktop and laptop image builds
- Installs from the `wezfurlong/wezterm-nightly` COPR repo, following the same add-repo/install/remove-repo pattern as Chrome and 1Password

## Why nightly?

WezTerm doesn't publish stable releases for current Fedora — the latest stable (Feb 2024) is over a year old, and the Flatpak ships with an EOL runtime (`org.freedesktop.Platform` 23.08). The nightly COPR is the recommended installation path per WezTerm's own documentation for Fedora/ublue systems.

## Future considerations

If the baked-in approach proves problematic (build breakage from nightly churn, etc.), an alternative is to install WezTerm inside a distrobox and use `distrobox-export` to surface it on the host. In that case we'd inject the distrobox install path in front of the system PATH rather than layering it into the image.

## Test plan

- [ ] `just build` succeeds and the resulting image has `wezterm` in PATH
- [ ] `just build-laptop` succeeds and the resulting image has `wezterm` in PATH
- [ ] WezTerm launches on Hyprland with working Wayland support

🤖 Generated with [Claude Code](https://claude.com/claude-code)