### PR TITLE
Add Thunderbolt/USB4 early-boot support to initrd

### DIFF
--- a/build_files/build-laptop.sh
+++ b/build_files/build-laptop.sh
@@ -14,6 +14,7 @@ function install-system() {
 	/ctx/install-chrome.sh
 	/ctx/install-wezterm.sh
 	/ctx/install-observability.sh
+	/ctx/install-thunderbolt.sh
 	/ctx/configure-xdg-portal.sh
 	/ctx/configure-signing-policy.sh
 	CELASTRINA_VARIANT="Laptop (Lunar Lake)" CELASTRINA_IMAGE_NAME="celastrina-laptop" /ctx/configure-branding.sh

--- a/build_files/build.sh
+++ b/build_files/build.sh
@@ -14,6 +14,7 @@ function install-system() {
     /ctx/install-chrome.sh
     /ctx/install-wezterm.sh
     /ctx/install-observability.sh
+    /ctx/install-thunderbolt.sh
     /ctx/configure-xdg-portal.sh
     /ctx/configure-signing-policy.sh
     /ctx/configure-branding.sh

--- a/build_files/install-thunderbolt.sh
+++ b/build_files/install-thunderbolt.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -ouex pipefail
+
+###############################################################################
+# Thunderbolt / USB4 early-boot support
+# Adds thunderbolt controller driver to initrd so NVMe storage and docks
+# behind Thunderbolt ports are available before root is mounted.
+###############################################################################
+
+install -Dm644 /dev/stdin /usr/lib/dracut/dracut.conf.d/thunderbolt.conf <<'EOF'
+# Thunderbolt/USB4 controller + USB HID — needed for keyboard/storage through TB docks
+force_drivers+=" thunderbolt thunderbolt-net usb_storage xhci-pci xhci-hcd usbhid "
+EOF


### PR DESCRIPTION
## Summary
- Adds `build_files/install-thunderbolt.sh` which drops a dracut config into `/usr/lib/dracut/dracut.conf.d/thunderbolt.conf`
- Uses `force_drivers` to unconditionally include `thunderbolt`, `thunderbolt-net`, `xhci-pci`, `xhci-hcd`, `usb_storage`, and `usbhid` in the initramfs
- Wired into both `build.sh` (desktop) and `build-laptop.sh` (laptop) image builds

## Motivation
Keyboards and storage behind Thunderbolt docks (e.g. CalDigit) need to be available at the LUKS passphrase prompt, before root is mounted. Without these modules in the initrd, the TB controller isn't initialized early enough for downstream USB HID devices to work.

## Test plan
- [ ] Build desktop image and verify `lsinitrd` shows thunderbolt/xhci/usbhid modules present
- [ ] Build laptop image and verify the same
- [ ] Boot with CalDigit TB dock connected, confirm keyboard works at LUKS unlock prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)