### PR TITLE
Add Ghostty terminal emulator to desktop and laptop images

### DIFF
--- a/build_files/build-laptop.sh
+++ b/build_files/build-laptop.sh
@@ -13,6 +13,7 @@ function install-system() {
 	/ctx/install-1password.sh
 	/ctx/install-chrome.sh
 	/ctx/install-wezterm.sh
+	/ctx/install-ghostty.sh
 	/ctx/install-observability.sh
 	/ctx/install-thunderbolt.sh
 	/ctx/configure-xdg-portal.sh

--- a/build_files/build.sh
+++ b/build_files/build.sh
@@ -13,6 +13,7 @@ function install-system() {
     /ctx/install-1password.sh
     /ctx/install-chrome.sh
     /ctx/install-wezterm.sh
+    /ctx/install-ghostty.sh
     /ctx/install-observability.sh
     /ctx/install-thunderbolt.sh
     /ctx/configure-xdg-portal.sh

--- a/build_files/install-ghostty.sh
+++ b/build_files/install-ghostty.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -ouex pipefail
+
+echo "Installing Ghostty"
+
+# Add COPR repo for ghostty
+curl -fsSL "https://copr.fedorainfracloud.org/coprs/scottames/ghostty/repo/fedora-$(rpm -E %fedora)/scottames-ghostty-fedora-$(rpm -E %fedora).repo" \
+    -o /etc/yum.repos.d/scottames-ghostty.repo
+
+# Install
+rpm-ostree install ghostty
+
+# Remove the repo — updates ship with new images
+rm /etc/yum.repos.d/scottames-ghostty.repo


### PR DESCRIPTION
## Summary
- Add `install-ghostty.sh` build script that installs Ghostty from the `scottames/ghostty` COPR repo
- Wire it into both `build.sh` (desktop) and `build-laptop.sh` (laptop) alongside WezTerm
- Follows the same COPR pattern as WezTerm: fetch repo file, `rpm-ostree install`, remove repo

## Test plan
- [ ] Verify `just build` completes successfully with the new script
- [ ] Verify `just build-laptop` completes successfully
- [ ] Confirm `ghostty` binary is present in the built image
- [ ] Confirm terminfo entry (`xterm-ghostty`) is installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)