### PR TITLE
Add legacy-tag cosign signing for bootc compatibility

### DIFF
--- a/.github/workflows/build-yoga9.yml
+++ b/.github/workflows/build-yoga9.yml
@@ -150,6 +150,9 @@ jobs:
         run: |
           cosign sign -y --key env://COSIGN_PRIVATE_KEY \
             "${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.push.outputs.digest }}"
+          cosign sign -y --key env://COSIGN_PRIVATE_KEY \
+            --registry-referrers-mode=legacy-tag \
+            "${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.push.outputs.digest }}"
         env:
           COSIGN_EXPERIMENTAL: false
           COSIGN_PRIVATE_KEY: ${{ secrets.SIGNING_SECRET }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -180,6 +180,9 @@ jobs:
         run: |
           cosign sign -y --key env://COSIGN_PRIVATE_KEY \
             "${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.push.outputs.digest }}"
+          cosign sign -y --key env://COSIGN_PRIVATE_KEY \
+            --registry-referrers-mode=legacy-tag \
+            "${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.push.outputs.digest }}"
         env:
           COSIGN_EXPERIMENTAL: false
           COSIGN_PRIVATE_KEY: ${{ secrets.SIGNING_SECRET }}

--- a/.github/workflows/sign.yml
+++ b/.github/workflows/sign.yml
@@ -1,0 +1,59 @@
+---
+name: Sign container image
+
+on:
+  workflow_dispatch:
+    inputs:
+      image:
+        description: "Image to sign"
+        required: true
+        type: choice
+        options:
+          - celastrina
+          - celastrina-yoga9
+
+env:
+  IMAGE_REGISTRY: "ghcr.io/${{ github.repository_owner }}"
+
+jobs:
+  sign:
+    name: Sign ${{ inputs.image }}:latest
+    runs-on: ubuntu-24.04
+
+    permissions:
+      packages: write
+      id-token: write
+
+    steps:
+      - name: Prepare environment
+        run: |
+          echo "IMAGE_REGISTRY=${IMAGE_REGISTRY,,}" >> ${GITHUB_ENV}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Get image digest
+        id: digest
+        run: |
+          DIGEST=$(skopeo inspect --format '{{.Digest}}' \
+            "docker://${IMAGE_REGISTRY}/${{ inputs.image }}:latest")
+          echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
+          echo "Signing ${IMAGE_REGISTRY}/${{ inputs.image }}@${DIGEST}"
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Sign container image
+        run: |
+          cosign sign -y --key env://COSIGN_PRIVATE_KEY \
+            "${IMAGE_REGISTRY}/${{ inputs.image }}@${{ steps.digest.outputs.digest }}"
+          cosign sign -y --key env://COSIGN_PRIVATE_KEY \
+            --registry-referrers-mode=legacy-tag \
+            "${IMAGE_REGISTRY}/${{ inputs.image }}@${{ steps.digest.outputs.digest }}"
+        env:
+          COSIGN_EXPERIMENTAL: false
+          COSIGN_PRIVATE_KEY: ${{ secrets.SIGNING_SECRET }}


### PR DESCRIPTION
## Summary
- Add a second `cosign sign` call with `--registry-referrers-mode=legacy-tag` to both build workflows, so signatures are published in both OCI referrers format (cosign v3 default) and the legacy `.sig` tag format that bootc/containers-image expects
- Add a new `sign.yml` dispatch-only workflow to re-sign existing images without a full rebuild

## Context
Cosign v3 defaults to OCI 1.1 referrers API for signature storage. GHCR supports this, so cosign never falls back to the legacy tag-based `.sig` attachment. However, bootc's `use-sigstore-attachments: true` registries.d config only discovers the legacy tag format, causing `A signature was required, but no signature exists` on `bootc upgrade`.

## Test plan
- [ ] Merge and let the next scheduled build run
- [ ] Verify `skopeo inspect` finds the `.sig` tag after the build
- [ ] Dispatch `sign.yml` for `celastrina-yoga9` to fix the current image immediately
- [ ] Verify `bootc upgrade` succeeds after signing

🤖 Generated with [Claude Code](https://claude.com/claude-code)