### PR TITLE
Pin cosign to v2.6.1 for containers/image compatibility

### DIFF
--- a/.github/workflows/build-yoga9.yml
+++ b/.github/workflows/build-yoga9.yml
@@ -149,14 +149,13 @@ jobs:
       - name: Install Cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
         if: github.event_name != 'pull_request' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+        with:
+          cosign-release: 'v2.6.1'
 
       - name: Sign container image
         if: github.event_name != 'pull_request' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
         run: |
           cosign sign -y --key env://COSIGN_PRIVATE_KEY \
-            "${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.push.outputs.digest }}"
-          cosign sign -y --key env://COSIGN_PRIVATE_KEY \
-            --registry-referrers-mode=legacy \
             "${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.push.outputs.digest }}"
         env:
           COSIGN_EXPERIMENTAL: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -173,14 +173,13 @@ jobs:
       - name: Install Cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
         if: github.event_name != 'pull_request' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+        with:
+          cosign-release: 'v2.6.1'
 
       - name: Sign container image
         if: github.event_name != 'pull_request' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
         run: |
           cosign sign -y --key env://COSIGN_PRIVATE_KEY \
-            "${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.push.outputs.digest }}"
-          cosign sign -y --key env://COSIGN_PRIVATE_KEY \
-            --registry-referrers-mode=legacy \
             "${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.push.outputs.digest }}"
         env:
           COSIGN_EXPERIMENTAL: false


### PR DESCRIPTION
## Summary

- Pin `sigstore/cosign-installer` to install cosign **v2.6.1** instead of the default (v3.x)
- Remove the redundant second `cosign sign` call with `--registry-referrers-mode=legacy`

## Problem

`rpm-ostree upgrade` fails with:
```
error: A signature was required, but no signature exists
```

Cosign v3 stores signatures as **OCI 1.1 referrers** using the new sigstore bundle v0.3 format. However, `containers/image` (used by rpm-ostree, skopeo, podman) with `use-sigstore-attachments: true` only discovers signatures via the legacy cosign tag format (`sha256-<digest>.sig`). These two don't interoperate — [containers/image #1848](https://github.com/containers/image/issues/1848) tracks adding OCI referrers support.

Cosign v2.6.1 (the last v2.x release) defaults to creating `.sig` tag attachments that `containers/image` can discover.

## Test plan

- [ ] CI build succeeds and signing step completes
- [ ] Verify `.sig` tag appears in GHCR: `skopeo list-tags docker://ghcr.io/butterflyskies/celastrina-yoga9`
- [ ] `rpm-ostree upgrade` succeeds on the Yoga 9
- [ ] `cosign verify --key /etc/pki/containers/butterflyskies.pub ghcr.io/butterflyskies/celastrina-yoga9:latest` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)