### PR TITLE
feat: add kmscon for TrueType console fonts

### DIFF
--- a/build_files/install-addon-packages.sh
+++ b/build_files/install-addon-packages.sh
@@ -27,6 +27,7 @@ dnf5 install -y \
   xorg-x11-server-Xwayland qt5-qtwayland qt6-qtwayland \
   iproute-tc iptables-nft nftables \
   jq yq \
+  kmscon \
   k9s \
   kubectl \
   kustomize \


### PR DESCRIPTION
## Summary
- Adds `kmscon` package to the image build
- kmscon is a KMS/DRM-based userspace console that supports TrueType/OpenType fonts via Pango, replacing the legacy fbcon with its 256-glyph bitmap limitation
- Enables full Nerd Font / Powerline glyph rendering on the Linux TTY
- Already in Fedora 44 repos; Fedora 45 is adopting it as the default VT console

## Test plan
- [ ] Build image and verify kmscon is installed
- [ ] Switch to a TTY and confirm kmscon is running
- [ ] Verify TrueType font rendering with Fira Code + Nerd Font symbols

🤖 Generated with [Claude Code](https://claude.com/claude-code)