### PR TITLE
Add remote display and connectivity tools

### DIFF
--- a/build_files/install-addon-packages.sh
+++ b/build_files/install-addon-packages.sh
@@ -8,6 +8,7 @@ dnf5 -y copr enable lionheartp/Hyprland
 dnf5 install -y \
   age \
   ansible ansible-lint \
+  autossh \
   bcachefs-tools \
   bpftool bpftrace \
   btrbk \
@@ -32,6 +33,7 @@ dnf5 install -y \
   kubectl \
   kustomize \
   libguestfs-tools \
+  mosh \
   neovim \
   netcat nmap \
   perf \
@@ -44,6 +46,8 @@ dnf5 install -y \
   tilt \
   virt-install virt-manager virt-viewer \
   v4l-utils \
+  waypipe \
+  xpra \
   zoxide \
   zsh zsh-syntax-highlighting
 


### PR DESCRIPTION
## Summary
- Add `autossh`, `mosh`, `waypipe`, and `xpra` to the image package list
- All four packages are available in the standard Fedora repos

## Test plan
- [ ] Verify image builds successfully with the new packages
- [ ] Confirm `waypipe` and `xpra` work for remote Wayland/X11 forwarding
- [ ] Confirm `mosh` and `autossh` work for resilient SSH sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)