### PR TITLE
fix: clean up Yoga 9 journal noise and boot errors

### DIFF
--- a/build_files/install-yoga9-extras.sh
+++ b/build_files/install-yoga9-extras.sh
@@ -14,7 +14,59 @@ set -ouex pipefail
 # Keyboard backlight control
 dnf5 install -y brightnessctl
 
-# Blacklist iwlwifi_mld — Intel BE201 WiFi 7 driver causes kernel panic on
-# the Yoga 9 2-in-1 14ILL10 during driver init. Regular iwlwifi works fine
-# as fallback. See: https://github.com/butterflyskies/celastrina/issues/5#2
-echo 'blacklist iwlwifi_mld' > /usr/lib/modprobe.d/blacklist-iwlwifi-mld.conf
+# --- Module blacklists ---
+
+# iwlwifi_mld — Intel BE201 WiFi 7 driver causes kernel panic during init.
+# Regular iwlwifi works fine as fallback.
+# See: https://github.com/butterflyskies/celastrina/issues/5#2
+rm -f /usr/lib/modprobe.d/blacklist-iwlwifi-mld.conf
+cat > /usr/lib/modprobe.d/celastrina-yoga9-blacklist.conf <<'MODPROBE'
+blacklist iwlwifi_mld
+blacklist lenovo_wmi_gamezone
+blacklist gcadapter_oc
+MODPROBE
+
+# --- Mask irrelevant hardware hooks from bazzite base ---
+
+# fw-fanctrl-suspend is for Framework laptops; fires every suspend cycle
+ln -sf /dev/null /usr/lib/systemd/system-sleep/fw-fanctrl-suspend
+
+# ThinkPad battery threshold udev rules fire 12x per boot on nonexistent sysfs
+install -m644 /dev/null /usr/lib/udev/rules.d/99-thinkpad-thresholds-udev.rules
+
+# --- Module load ordering ---
+
+# tcp_bbr must be loaded before sysctl sets net.ipv4.tcp_congestion_control
+install -d /usr/lib/modules-load.d
+echo 'tcp_bbr' > /usr/lib/modules-load.d/celastrina-bbr.conf
+
+# --- Fix tuned-ppd power profile switching ---
+# tuned-ppd crashes parsing composite profile strings (space-separated).
+# Drop accelerator-performance from the performance mapping — its aggressive
+# CPU pinning and scheduler tweaks aren't needed on a Yoga ultrabook.
+install -d /etc/tuned
+cat > /etc/tuned/ppd.conf <<'PPD'
+[main]
+default=performance
+battery_detection=true
+sysfs_acpi_monitor=true
+[profiles]
+power-saver=powersave-bazzite
+balanced=balanced-bazzite
+performance=throughput-performance-bazzite
+[battery]
+balanced=balanced-battery-bazzite
+power-saver=powersave-battery-bazzite
+PPD
+
+# --- SELinux local policy ---
+# Suppress known denials from ostree/bootc environment:
+#   - bootupd_t running lsblk (user/group resolution, mount info)
+#   - systemd-logind inspecting unlabeled /boot/efi
+#   - SDDM checking /run/ostree-booted
+#   - podman pasta traversing ~/.local
+checkmodule -M -m -o /tmp/celastrina-yoga9.mod /ctx/selinux/celastrina-yoga9.te
+semodule_package -o /tmp/celastrina-yoga9.pp -m /tmp/celastrina-yoga9.mod
+install -D -m644 /tmp/celastrina-yoga9.pp /usr/share/selinux/packages/celastrina-yoga9.pp
+semodule -i /tmp/celastrina-yoga9.pp
+rm -f /tmp/celastrina-yoga9.{mod,pp}

--- a/build_files/selinux/celastrina-yoga9.te
+++ b/build_files/selinux/celastrina-yoga9.te
@@ -1,0 +1,43 @@
+module celastrina-yoga9 1.0.0;
+
+require {
+    type bootupd_t;
+    type mount_var_run_t;
+    type passwd_file_t;
+    type proc_t;
+    type systemd_homed_t;
+    type systemd_machined_t;
+    type systemd_userdbd_t;
+    type systemd_userdbd_runtime_t;
+    type systemd_logind_t;
+    type unlabeled_t;
+    type xdm_t;
+    type install_var_run_t;
+    type pasta_t;
+    type gconf_home_t;
+    class dir { getattr open read search };
+    class file { getattr open read };
+    class lnk_file read;
+    class sock_file write;
+    class unix_stream_socket connectto;
+}
+
+# bootupd runs lsblk which needs user/group resolution and mount info
+allow bootupd_t mount_var_run_t:dir search;
+allow bootupd_t passwd_file_t:file { getattr open read };
+allow bootupd_t proc_t:file { getattr open read };
+allow bootupd_t systemd_homed_t:unix_stream_socket connectto;
+allow bootupd_t systemd_machined_t:unix_stream_socket connectto;
+allow bootupd_t systemd_userdbd_runtime_t:dir { getattr open read search };
+allow bootupd_t systemd_userdbd_runtime_t:lnk_file read;
+allow bootupd_t systemd_userdbd_runtime_t:sock_file write;
+allow bootupd_t systemd_userdbd_t:unix_stream_socket connectto;
+
+# systemd-logind inspects /boot/efi which is unlabeled on ostree
+allow systemd_logind_t unlabeled_t:dir getattr;
+
+# SDDM checks /run/ostree-booted
+allow xdm_t install_var_run_t:file getattr;
+
+# podman pasta networking traverses ~/.local
+allow pasta_t gconf_home_t:dir search;


### PR DESCRIPTION
## Summary

- **Module blacklists**: Add `lenovo_wmi_gamezone` (Legion laptops) and `gcadapter_oc` (GameCube adapter) to the Yoga 9 blacklist alongside existing `iwlwifi_mld`. Consolidates into single config file.
- **Mask irrelevant base image hooks**: Symlink `fw-fanctrl-suspend` to `/dev/null` (Framework laptop fan control fires every 15-min suspend cycle), override ThinkPad battery threshold udev rules (fires 12x/boot on nonexistent sysfs).
- **Module load ordering**: Ensure `tcp_bbr` loads before sysctl tries to set `net.ipv4.tcp_congestion_control=bbr`.
- **Fix tuned-ppd crash**: The Bazzite `ppd.conf` maps performance to a space-separated composite profile string (`throughput-performance-bazzite accelerator-performance`) which crashes tuned-ppd's parser. This breaks all power profile switching — battery/AC auto-switching, the balanced/performance/power-saver desktop toggle. Fix: use single profile for performance mode.
- **SELinux local policy**: Compile and install a policy module covering known ostree/bootc environment denials — bootupd running lsblk, systemd-logind inspecting unlabeled `/boot/efi`, SDDM checking `/run/ostree-booted`, podman pasta traversing `~/.local`.

## Context

Journal diagnosis on psyche (Yoga 9 / Lunar Lake) revealed ~29 distinct recurring errors/warnings. This PR addresses the ones fixable in the image build. Remaining items (virtqemud boot ordering race, NM/IWD transient resume errors, xe driver s2idle crash) are tracked separately.

## Test plan

- [ ] Build the yoga9 image locally with `just build-yoga9`
- [ ] Verify `tuned-ppd.service` starts successfully and `tuned-adm active` shows a single profile
- [ ] Verify power profile switching works: `powerprofilesctl set balanced && powerprofilesctl set performance`
- [ ] Check `journalctl -b 0 -p err` is significantly quieter
- [ ] Verify `ausearch -m avc --start today | grep denied` shows no bootupd/logind/xdm/pasta denials
- [ ] Confirm WiFi still works (iwlwifi fallback unaffected by consolidated blacklist file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)