### PR TITLE
chore: add xwayland-satellite

### DIFF
--- a/build_files/install-addon-packages.sh
+++ b/build_files/install-addon-packages.sh
@@ -25,7 +25,7 @@ dnf5 install -y \
   grim \
   helm \
   htop \
-  xorg-x11-server-Xwayland qt5-qtwayland qt6-qtwayland \
+  xorg-x11-server-Xwayland xwayland-satellite qt5-qtwayland qt6-qtwayland \
   iproute-tc iptables-nft nftables \
   jq yq \
   kmscon \


### PR DESCRIPTION
## Summary
- Add `xwayland-satellite` to the addon packages list for native Wayland X11 bridging
- Complements `waypipe` for forwarding X11 apps over Wayland sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)