### PR TITLE
fix(yoga9): Lunar Lake stability kargs + strip NVIDIA kargs

### DIFF
--- a/build_files/install-yoga9-extras.sh
+++ b/build_files/install-yoga9-extras.sh
@@ -59,6 +59,54 @@ balanced=balanced-battery-bazzite
 power-saver=powersave-battery-bazzite
 PPD
 
+# --- Kernel arguments (bootc kargs.d) ---
+
+# bootc applies kargs.d/*.toml at image install/upgrade time.
+# Priority prefix "99-" ensures these run after Bazzite's base entries.
+
+install -d /usr/lib/bootc/kargs.d
+
+# Lunar Lake stability: prevent xe GPU hangs (PSR) and C-state lockups.
+# xe.enable_psr=0   — disables Panel Self Refresh on Intel Xe; avoids display/GPU hang
+# intel_idle.max_cstate=1 — caps CPU idle to C1; prevents deep-sleep-induced hangs on LNL
+install -m644 /dev/stdin /usr/lib/bootc/kargs.d/99-celastrina-yoga9-stability.toml <<'KARGS'
+# Lunar Lake (Intel Arc Xe2) stability parameters for Yoga 9 14ILL10.
+# See: https://gitlab.freedesktop.org/drm/xe/kernel/-/issues (PSR hangs)
+#      https://bugzilla.kernel.org/show_bug.cgi?id=218204 (LNL C-state lockups)
+
+[[add]]
+key = "xe.enable_psr"
+value = "0"
+
+[[add]]
+key = "intel_idle.max_cstate"
+value = "1"
+KARGS
+
+# Strip NVIDIA kargs shipped by the bazzite base image.
+# The yoga9 variant uses bazzite:stable (no NVIDIA), but the base image's
+# kargs.d may still propagate these; remove them so they never appear on boot.
+install -m644 /dev/stdin /usr/lib/bootc/kargs.d/99-celastrina-yoga9-strip-nvidia.toml <<'KARGS'
+# Remove NVIDIA-specific kernel arguments — the Yoga 9 has no discrete GPU.
+# Bazzite:stable may still ship these from its common kargs.d layer.
+
+[[delete]]
+key = "nvidia-drm.modeset"
+value = "1"
+
+[[delete]]
+key = "rd.driver.blacklist"
+value = "nouveau"
+
+[[delete]]
+key = "modprobe.blacklist"
+value = "nouveau"
+
+[[delete]]
+key = "gpu_sched.sched_policy"
+value = "0"
+KARGS
+
 # --- SELinux local policy ---
 # Suppress known denials from ostree/bootc environment:
 #   - bootupd_t running lsblk (user/group resolution, mount info)


### PR DESCRIPTION
## Summary

- **Add Lunar Lake stability kernel parameters** via `bootc kargs.d`:
  - `xe.enable_psr=0` — disables Panel Self Refresh on the Intel Xe2 GPU to prevent xe driver display/GPU hangs
  - `intel_idle.max_cstate=1` — caps CPU idle to C1, preventing deep C-state lockups on Lunar Lake (LNL)

- **Strip NVIDIA kargs** inherited from the Bazzite base image:
  - `nvidia-drm.modeset=1`, `rd.driver.blacklist=nouveau`, `modprobe.blacklist=nouveau`, `gpu_sched.sched_policy=0`
  - The yoga9 variant uses `bazzite:stable` (Intel-only), but Bazzite's common `kargs.d` layer may still propagate these; they are irrelevant and potentially harmful on the Yoga 9 14ILL10.

Both changes are implemented in `build_files/install-yoga9-extras.sh` using two `/usr/lib/bootc/kargs.d/*.toml` files installed during the container build. bootc applies these at image install time and on each upgrade — no manual bootloader edits needed.

## Files changed

- `build_files/install-yoga9-extras.sh` — new "Kernel arguments" section installing:
  - `99-celastrina-yoga9-stability.toml` (`[[add]]` entries for xe + intel_idle)
  - `99-celastrina-yoga9-strip-nvidia.toml` (`[[delete]]` entries for four NVIDIA kargs)

## Test plan

- [ ] Build yoga9 image: `just build-yoga9`
- [ ] Verify `/usr/lib/bootc/kargs.d/` contains both TOML files in the built image
- [ ] Boot image; confirm `xe.enable_psr=0 intel_idle.max_cstate=1` present in `/proc/cmdline`
- [ ] Confirm `nvidia-drm.modeset`, `rd.driver.blacklist=nouveau`, `modprobe.blacklist=nouveau`, `gpu_sched.sched_policy=0` absent from `/proc/cmdline`
- [ ] Verify no GPU or C-state hangs during suspend/resume cycles

🤖 Generated with [Claude Code](https://claude.com/claude-code)