### PR TITLE
chore(deps): consolidated dependency updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -19,6 +19,18 @@
   ],
   packageRules: [
     {
+      groupName: 'github-actions',
+      matchManagers: [
+        'github-actions',
+      ],
+    },
+    {
+      groupName: 'docker-dependencies',
+      matchDatasources: [
+        'docker',
+      ],
+    },
+    {
       automerge: true,
       matchUpdateTypes: [
         'pin',

--- a/.github/workflows/build-disk.yml
+++ b/.github/workflows/build-disk.yml
@@ -79,7 +79,7 @@ jobs:
 
       - name: Build disk images
         id: build
-        uses: osbuild/bootc-image-builder-action@31d72f795564fb09943f0705025e75748da3a2d1 # main
+        uses: osbuild/bootc-image-builder-action@0b0e47a036d8660dd8dfc00407598f16d9f40cbc # main
         with:
           builder-image: ${{ env.BIB_IMAGE }}
           config-file: ${{ matrix.disk-type == 'anaconda-iso' && './disk_config/iso.toml' || './disk_config/disk.toml' }}

--- a/.github/workflows/build-disk.yml
+++ b/.github/workflows/build-disk.yml
@@ -75,7 +75,7 @@ jobs:
           remove-codeql: true
 
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Build disk images
         id: build

--- a/.github/workflows/build-yoga9.yml
+++ b/.github/workflows/build-yoga9.yml
@@ -49,7 +49,7 @@ jobs:
           echo "IMAGE_NAME=${IMAGE_NAME,,}" >> ${GITHUB_ENV}
 
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Maximize build space
         uses: ublue-os/remove-unwanted-software@cc0becac701cf642c8f0a6613bbdaf5dc36b259e # v9

--- a/.github/workflows/build-yoga9.yml
+++ b/.github/workflows/build-yoga9.yml
@@ -74,7 +74,7 @@ jobs:
           echo "date=$(date -u +%Y\-%m\-%d\T%H\:%M\:%S\Z)" >> $GITHUB_OUTPUT
 
       - name: Image Metadata
-        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         id: metadata
         with:
           tags: |

--- a/.github/workflows/build-yoga9.yml
+++ b/.github/workflows/build-yoga9.yml
@@ -125,7 +125,7 @@ jobs:
             --secret id=dkms_cert,env=DKMS_CERT
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         if: github.event_name != 'pull_request' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
         with:
           registry: ghcr.io

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -145,7 +145,7 @@ jobs:
       # These `if` statements are so that pull requests for your custom images do not make it publish any packages under your name without you knowing
       # They also check if the runner is on the default branch so that things like the merge queue (if you enable it), are going to work
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         if: github.event_name != 'pull_request' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
         with:
           registry: ghcr.io

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,7 +66,7 @@ jobs:
       # Image metadata for https://artifacthub.io/ - This is optional but is highly recommended so we all can get a index of all the custom images
       # The metadata by itself is not going to do anything, you choose if you want your image to be on ArtifactHub or not.
       - name: Image Metadata
-        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         id: metadata
         with:
           # This generates all the tags for your image, you can add custom tags here too!

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
 
       # These stage versions are pinned by https://github.com/renovatebot/renovate
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Maximize build space
         uses: ublue-os/remove-unwanted-software@cc0becac701cf642c8f0a6613bbdaf5dc36b259e # v9

--- a/.github/workflows/sign.yml
+++ b/.github/workflows/sign.yml
@@ -30,7 +30,7 @@ jobs:
           echo "IMAGE_REGISTRY=${IMAGE_REGISTRY,,}" >> ${GITHUB_ENV}
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/Containerfile
+++ b/Containerfile
@@ -7,7 +7,7 @@ COPY build_files /
 COPY cosign.pub /cosign.pub
 
 # Build Rio terminal from source (Wayland + librashader filters)
-FROM rust:latest@sha256:5b1e3484ddcd22a3738c0ec34a5e98bf19382eb295fb6db54295e62379119040 AS rio-builder
+FROM rust:latest@sha256:fb328f0f58becb23ba1719940a2c94ece8b0b48afa837d05b79ef64bc1e18f6e AS rio-builder
 ARG RIO_VERSION=v0.4.4
 RUN apt-get update && apt-get install -y --no-install-recommends \
     cmake pkg-config libfreetype6-dev libfontconfig1-dev libxcb-xfixes0-dev libxkbcommon-dev glslang-tools


### PR DESCRIPTION
## Summary

Consolidates all passing dependency bump PRs into a single update. Also adds grouping rules to `renovate.json5` so future dependency updates are batched into fewer PRs.

### Included PRs (all passing CI)
- #40: Update rust:latest Docker digest to fb328f0
- #41: Update osbuild/bootc-image-builder-action digest to 0b0e47a
- #42: Update actions/checkout action to v6.0.3 — **superseded by #45 (v7)**
- #45: Update actions/checkout action to v7.0.0
- #47: Update docker/login-action action to v4.4.0
- #48: Update docker/metadata-action action to v6.2.0

### Excluded PRs (failing CI)
- #49: Bump the github-actions group across 1 directory with 4 updates — **CI failing**
- #50: Update ghcr.io/ublue-os/bazzite-nvidia-open:stable Docker digest — **CI failing**
- #51: Update redhat-actions/buildah-build action to v3 — **CI failing**
- #52: Update redhat-actions/push-to-registry action to v3 — **CI failing**

### Config changes
- Added `groupName: 'github-actions'` rule to `.github/renovate.json5` to batch GitHub Actions updates
- Added `groupName: 'docker-dependencies'` rule to `.github/renovate.json5` to batch Docker updates
- `.github/dependabot.yml` already has `groups.github-actions` configured — no changes needed

### Notes
- #42 (checkout v6.0.3) and #45 (checkout v7) both modify the same lines; #45 supersedes #42 as the newer major version, so only #45 was merged
- Original PRs are left open intentionally — close them after this PR is merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)